### PR TITLE
Add 'requests_encoding' parameter

### DIFF
--- a/agateremote/table_remote.py
+++ b/agateremote/table_remote.py
@@ -8,7 +8,7 @@ import agate
 import requests
 import six
 
-def from_url(cls, url, callback=agate.Table.from_csv, binary=False, **kwargs):
+def from_url(cls, url, callback=agate.Table.from_csv, requests_encoding=None, binary=False, **kwargs):
     """
     Download a remote file and pass it to a :class:`.Table` parser.
 
@@ -18,11 +18,17 @@ def from_url(cls, url, callback=agate.Table.from_csv, binary=False, **kwargs):
         The method to invoke to create the table. Typically either
         :meth:`agate.Table.from_csv` or :meth:`agate.Table.from_json`, but
         it could also be a method provided by an extension.
+    :param requests_encoding:
+        An encoding to pass to requests for use when decoding the response
+        content. (e.g. force use of 'utf-8-sig' when CSV has a BOM).
     :param binary:
         If :code:`False` the downloaded data will be processed as a string,
         otherwise it will be treated as binary data. (e.g. for Excel files)
     """
     r = requests.get(url)
+
+    if requests_encoding:
+        r.encoding = requests_encoding
 
     if binary:
         content = six.BytesIO(r.content)


### PR DESCRIPTION
Allows user to override Requests' "educated guess" about encoding of a response. Useful, for example, when you want to force Requests to use a `utf-8-sig` encoding instead of an `ISO-8859-1` encoding when retrieving a remote CSV that has a BOM but was served with a `text/csv` content-type.